### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": ["typo3", "TYPO3 CMS", "mysql", "status", "widget"],
 	"homepage": "https://www.typo3lexikon.de",
-	"version": "0.1.0",
 	"authors": [
 		{
 			"name": "Stefan Froemken",


### PR DESCRIPTION
The version is set hard to 0.1.0 which means that Packagist does not know about version 0.2.0. Without the version constraint in composer.json the version of the tag/release takes place.